### PR TITLE
Potential fix for code scanning alert no. 42: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -567,7 +567,7 @@ def health_check():
     except Exception as e:
         logger.error(f"Health check failed: {e}")
         db.log_message("ERROR", f"Health check failed: {e}", "webapp")
-        return jsonify({'status': 'unhealthy', 'error': str(e)}), 500
+        return jsonify({'status': 'unhealthy', 'error': 'A server error occurred'}), 500
 
 @app.route('/api/cache-stats')
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/ufcrashout/iTrax/security/code-scanning/42](https://github.com/ufcrashout/iTrax/security/code-scanning/42)

To fix the problem, ensure that exception details are not sent to the client in API responses. Instead, log the detail server-side (as already being done), and send only a generic error message in the response.

**How to fix:**
- Replace `"error": str(e)` in the response JSON with a fixed, generic string (e.g., `"A server error occurred"`).
- Make the change at line 570, where the unhealthy message is returned.

**Details:**
- Edit only the response message: `{'status': 'unhealthy', 'error': str(e)}` → `{'status': 'unhealthy', 'error': 'A server error occurred'}`.
- No additional imports or definitions required in this case, as error logging is already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
